### PR TITLE
test: Mark uncaught TypeErrors in NdefRecord

### DIFF
--- a/ndef/ndef.py
+++ b/ndef/ndef.py
@@ -111,11 +111,11 @@ class NdefRecord(object):
         self.flags = NdefRecordFlags()
         self.tnf = TNF_EMPTY
         self.type_len = 0
-        self.type = None
+        self.type = b''
         self.id_len = 0
-        self.id = None
+        self.id = b''
         self.payload_len = 0
-        self.payload = None
+        self.payload = b''
 
         if reader is None:
             return
@@ -151,7 +151,7 @@ class NdefRecord(object):
         if self.flags.id:
             self.id = reader.read(self.id_len)
         else:
-            self.id = None
+            self.id = b''
 
         self.payload = reader.read(self.payload_len)
 

--- a/tests/ndef_test.py
+++ b/tests/ndef_test.py
@@ -201,13 +201,11 @@ class TestNdefClass(unittest.TestCase):
 
         ndefrecord.verify()
 
-    @unittest.expectedFailure
     def test_invalid_to_buffer_no_type(self) -> None:
         ndefrecord = NdefRecord()
 
         ndefrecord.to_buffer()
 
-    @unittest.expectedFailure
     def test_invalid_to_buffer_no_id(self) -> None:
         ndefrecord = NdefRecord()
         ndefrecord.type = b''
@@ -215,7 +213,6 @@ class TestNdefClass(unittest.TestCase):
 
         ndefrecord.to_buffer()
 
-    @unittest.expectedFailure
     def test_invalid_to_buffer_no_payload(self) -> None:
         ndefrecord = NdefRecord()
         ndefrecord.type = b''

--- a/tests/ndef_test.py
+++ b/tests/ndef_test.py
@@ -4,7 +4,7 @@ import unittest
 import six
 
 from ndef.ndef import BufferReader, InvalidNdef, NdefMessage, InvalidNdefMessage, InvalidNdefRecord, new_message, \
-    TNF_EMPTY, TNF_WELL_KNOWN, RTD_TEXT, BufferWriter, new_smart_poster, _url_ndef_abbrv
+    TNF_EMPTY, TNF_WELL_KNOWN, RTD_TEXT, BufferWriter, new_smart_poster, _url_ndef_abbrv, NdefRecord, RTD_URI
 
 
 # TODO chunked
@@ -184,3 +184,40 @@ class TestNdefClass(unittest.TestCase):
         self.assertEqual(_url_ndef_abbrv('http://test.com'), six.b('\x03test.com'))
         self.assertEqual(_url_ndef_abbrv('https://test.com'), six.b('\x04test.com'))
         self.assertEqual(_url_ndef_abbrv('myproto://test.com'), six.b('\x00myproto://test.com'))
+
+    @unittest.expectedFailure
+    def test_invalid_verify_rtd_text(self) -> None:
+        ndefrecord = NdefRecord()
+        ndefrecord.tnf = TNF_WELL_KNOWN
+        ndefrecord.type = RTD_TEXT
+
+        ndefrecord.verify()
+
+    @unittest.expectedFailure
+    def test_invalid_verify(self) -> None:
+        ndefrecord = NdefRecord()
+        ndefrecord.tnf = TNF_WELL_KNOWN
+        ndefrecord.type = RTD_URI
+
+        ndefrecord.verify()
+
+    @unittest.expectedFailure
+    def test_invalid_to_buffer_no_type(self) -> None:
+        ndefrecord = NdefRecord()
+
+        ndefrecord.to_buffer()
+
+    @unittest.expectedFailure
+    def test_invalid_to_buffer_no_id(self) -> None:
+        ndefrecord = NdefRecord()
+        ndefrecord.type = b''
+        ndefrecord.flags.id = True
+
+        ndefrecord.to_buffer()
+
+    @unittest.expectedFailure
+    def test_invalid_to_buffer_no_payload(self) -> None:
+        ndefrecord = NdefRecord()
+        ndefrecord.type = b''
+
+        ndefrecord.to_buffer()


### PR DESCRIPTION
Good afternoon;
I played around with type checking and found five paths, which lead to uncaught TypeErrors due to optional fields in `NdefRecord`: `type`, `id` and `payload`.

There are eleven read accesses falsely assuming these fields would not be `None`.
Six of them are being shadowed by the five I marked in the tests.

Are these indeed expected? Or should they be caught?